### PR TITLE
Fix code contributor URL

### DIFF
--- a/views/pages/about.html
+++ b/views/pages/about.html
@@ -35,7 +35,7 @@
   <div class="row">
   {{ range $i, $c := .CodeContributors }}
     <div class="col-2" style="margin-bottom:20px">
-      <a href="https://github.com/ConfWatch/confwatch-data/commits?author={{ $c.Login }}" target="_blank">
+      <a href="https://github.com/ConfWatch/confwatchd/commits?author={{ $c.Login }}" target="_blank">
         <img 
             width="150px" 
             src="{{ $c.AvatarURL }}" 


### PR DESCRIPTION
Fixed URL to code contributors, which was pointing to confwatch-data instead of confwatchd.